### PR TITLE
Fixing error "memory.memsw.usage_in_bytes : no such file or directory" when running stand alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,23 @@ grained reporting):
 And there is even a handy flag to modify the environment:
 
     $ mstat -o data/mem.tsv -freq 59 -env LD_PRELOAD=libawesome.so -- ./test
+
+### Use `mstat` without Docker ###
+Prerequisite:
+* [golang](https://golang.org/)
+
+After installing golang and cloning this repository, download all the go dependencies with the command
+
+    $ cd mstat
+    $ go get -d ./...
+
+Then proceed with make and installation. If you want to be able to uninstall
+`mstat` later, instead of using `make install`, use the command below
+
+    $ sudo checkinstall
+
+You will be able to uninstall `mstat` by running
+
+    $ sudo dpkg -r mstat
+
+later. 

--- a/poller.go
+++ b/poller.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/cgroups/stats/v1"
 )
 
 type Record struct {
@@ -20,7 +21,8 @@ type Record struct {
 
 type Stats struct {
 	Rss   []Record
-	Stats []*cgroups.MemoryStat
+	Stats []*v1.Metrics
+	// Stats []*cgroups.MemoryStat
 }
 
 type endReq struct {

--- a/poller.go
+++ b/poller.go
@@ -60,7 +60,7 @@ func NewPoller(cgroup cgroups.Cgroup, freq int) (*Poller, error) {
 
 func (p *Poller) poll(t time.Time, cgroup cgroups.Cgroup) error {
 
-	stats, err := cgroup.Stat()
+	stats, err := cgroup.Stat(cgroups.ErrorHandler(cgroups.IgnoreNotExist))
 	if err != nil || stats == nil {
 		return fmt.Errorf("cg.Stat: %s", err)
 	}


### PR DESCRIPTION
First of all, mstat is a fantastic tool and it may turn out to be life saving for me. 

That said, when running mstat on Ubuntu 18.04, I noticed that I am getting errors along the line of 
`2019/09/10 09:26:24 NewPoller: poll: cg.Stat: open /sys/fs/cgroup/memory/mstat-50217553c85dcda3/memory.memsw.usage_in_bytes: no such file or directory`

The fix is following this post 
https://github.com/containerd/cgroups/issues/5

And it seems the problem is gone. A bit more documentation is also added. I am new to both cgroup and golang so I am not sure if what I have done is sensible at all. But at least mstat is reporting reasonable numbers. 

